### PR TITLE
feat: rearchitecture interface

### DIFF
--- a/lib/rettle.rb
+++ b/lib/rettle.rb
@@ -22,16 +22,17 @@ class Rettle
     end
   end
 
-  def socket(task_names)
-    tasks = task_names.map{|name| @tasks[name]}
+  def connect(task_names)
+    tasks = task_names.each_with_object({}){|name, hash| hash[name] = @tasks[name]}
     if block_given?
       yield tasks
-      tasks.each(&:close)
+      tasks.values.each(&:close)
     end
   end
 
   def send(name, data)
     task = @tasks[name]
+    task.connect
     task.write(data)
   end
 

--- a/lib/rettle/network.rb
+++ b/lib/rettle/network.rb
@@ -1,0 +1,29 @@
+class Rettle
+  class Network
+    def initialize(type: :pipe)
+      @type = type
+      server_open
+    end
+
+    def server_open
+      case @type
+      when :pipe
+        @fds = IO.pipe
+      end
+    end
+
+    def read_fd
+      case @type
+      when :pipe
+        @fds[0]
+      end
+    end
+
+    def write_fd
+      case @type
+      when :pipe
+        @fds[1]
+      end
+    end
+  end
+end


### PR DESCRIPTION
- etlのユーザのコードからtaskを直接意識しないようにinterfaceを修正
- Task間の通信処理をNetwork classへ独立化